### PR TITLE
In linked queries, don't refer to joined tables when joining `cards`

### DIFF
--- a/lib/backend/postgres/jsonschema2sql/sql-query.ts
+++ b/lib/backend/postgres/jsonschema2sql/sql-query.ts
@@ -184,20 +184,15 @@ const pushLinkedJoins = (
 			SELECT id
 			FROM strings
 			WHERE string = ${linked.linkName}
-		)
-	`);
-	innerSelect.pushLeftJoin('links2', linksFilter, linked.linksAlias);
-	const joinFilter = new LiteralSql(`(
-		${linked.linksAlias}.name = (
-			SELECT id
-			FROM strings
-			WHERE string = ${linked.linkName}
 		) AND
 		${linked.linksAlias}.toId = ${linked.joinAlias}.id
-	) AND (
-		${linked.sqlFilter}
-	)`);
-	innerSelect.pushLeftJoin(cardsTable, joinFilter, linked.joinAlias);
+	`);
+	innerSelect.pushLeftJoin(
+		cardsTable,
+		new LiteralSql(linked.sqlFilter),
+		linked.joinAlias,
+	);
+	innerSelect.pushLeftJoin('links2', linksFilter, linked.linksAlias);
 };
 
 const pushLinkedLateral = (


### PR DESCRIPTION
This reduces to queries to the `strings` table and apparently allows more freedom to the query planner.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>