### PR TITLE
Add relationship validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,40 @@ Measurable are gathered and observed using prometheus/grafana.
 
 ### Data relationships
 
-Contracts can be linked together by creating a contract of type "link" that references both contracts and describes their relationship. Relationships can be traversed when querying data using the `$$links` syntax.
+Contracts can be linked together by creating a contract of type `link` that references both contracts and describes their relationship. Relationships can be traversed when querying data using the `$$links` syntax.
+
+`Link` contracts are described by a [`relationship` contract](./lib/contracts/relationship.ts). Relationship contracts relate two contracts which are specified using the `from.type` and `to.type` properties, and describe two directions, from `from` to `to` using the `name` property, and from `to` to `from` using the `inverseName` property.
+
+Example:
+
+```ts
+{
+  slug: `relationship-message-is-attached-to-issue`,
+  type: 'relationship@1.0.0',
+  name: 'is attached to',
+  data: {
+  	inverseName: 'has attached element',
+  	title: 'Message',
+  	inverseTitle: 'Issue',
+  	from: {
+  		type: 'message',
+  	},
+  	to: {
+  		type: 'issue',
+  	},
+  },
+},
+```
+
+Note that `from.type` and `to.type` can refer to contracts by their slug ( `card` ) or if you want a more specific relationship they can refer to the versioned slug ( `card@1.0.0` ).
+
+Relationships are bidirectional, `name` goes from `from` to `to` ( _{message} is attached to {issue}_ ), and `inverseName` goes from `to` to `from` ( _{issue} has attached element {message}_ ). Note that both directions have the same precedence; they're named `name` and `inverseName` for historical reasons but could've also been named `left` and `right`. Relationships contracts also have a `title` and `inverseTitle` property that can be used to describe the role of the `from` and `to` contracts.
+
+All links ( contracts of type `link` ) created must be defined by a `relationship` contract or the link creation will be rejected with a `JellyfishUnknownRelationship` error. Client modules, for example `jellyfish-worker` create a set of "bootstrap" relationships on initialization.
 
 ### Caching
 
-Requests for individual contracts by id or slug are cached, reducing DB load and
-improving query speed.
+Requests for individual contracts by id or slug are cached, reducing DB load and improving query speed.
 
 # Testing
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -42,3 +42,4 @@ export class JellyfishSchemaMismatch extends BaseTypedError {}
 export class JellyfishSessionExpired extends BaseTypedError {}
 export class JellyfishTransactionError extends BaseTypedError {}
 export class JellyfishUnknownCardType extends BaseTypedError {}
+export class JellyfishUnknownRelationship extends BaseTypedError {}

--- a/test/integration/kernel.link.spec.ts
+++ b/test/integration/kernel.link.spec.ts
@@ -1,0 +1,580 @@
+import { strict as assert } from 'assert';
+import * as _ from 'lodash';
+import { v4 as uuid } from 'uuid';
+import { errors, testUtils } from '../../lib';
+
+let ctx: testUtils.TestContext;
+
+beforeAll(async () => {
+	ctx = await testUtils.newContext();
+});
+
+afterAll(async () => {
+	await testUtils.destroyContext(ctx);
+});
+
+describe('Kernel', () => {
+	describe('.insertContract() links', () => {
+		it('should be able to create a link between two valid contracts', async () => {
+			const contract1 = await insertCardContract();
+
+			const contract2 = await insertCardContract();
+
+			await upsertRelationshipCardIsAttachedTo();
+
+			const linkContract = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `link-${contract1.slug}-is-attached-to-${contract2.slug}`,
+					type: 'link@1.0.0',
+					name: 'is attached to',
+					data: {
+						inverseName: 'has attached element',
+						from: {
+							id: contract1.id,
+							type: contract1.type,
+						},
+						to: {
+							id: contract2.id,
+							type: contract2.type,
+						},
+					},
+				},
+			);
+
+			const element = await ctx.kernel.getContractById(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				linkContract.id,
+			);
+
+			assert(element !== null);
+
+			expect(element.data.from).not.toBe(element.data.to);
+		});
+
+		it('should be able to create a direction-less link between two valid contracts', async () => {
+			const contract1 = await insertCardContract();
+			const contract2 = await insertCardContract();
+			await upsertRelationshipIsLinkedTo();
+
+			const linkContract = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `link-${contract1.slug}-is-linked-to-${contract2.slug}`,
+					type: 'link@1.0.0',
+					name: 'is linked to',
+					data: {
+						inverseName: 'is linked to',
+						from: {
+							id: contract1.id,
+							type: contract1.type,
+						},
+						to: {
+							id: contract2.id,
+							type: contract2.type,
+						},
+					},
+				},
+			);
+
+			const element = await ctx.kernel.getContractById(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				linkContract.id,
+			);
+			assert(element !== null);
+			expect(element.data.from).not.toBe(element.data.to);
+			expect(element.name).toBe(element.data.inverseName);
+		});
+
+		it('should be able to create two different links between two valid contracts', async () => {
+			const contract1 = await insertCardContract();
+
+			const contract2 = await insertCardContract();
+
+			await upsertRelationshipCardIsAttachedTo();
+
+			const linkContract1 = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `link-${contract1.slug}-is-linked-to-${contract2.slug}`,
+					type: 'link@1.0.0',
+					version: '1.0.0',
+					name: 'is attached to',
+					data: {
+						inverseName: 'has attached element',
+						from: {
+							id: contract1.id,
+							type: contract1.type,
+						},
+						to: {
+							id: contract2.id,
+							type: contract2.type,
+						},
+					},
+				},
+			);
+
+			const linkContract2 = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `link-${contract1.slug}-is-attached-to-${contract2.slug}`,
+					type: 'link@1.0.0',
+					version: '1.0.0',
+					name: 'is attached to',
+					data: {
+						inverseName: 'has attached element',
+						from: {
+							id: contract1.id,
+							type: contract1.type,
+						},
+						to: {
+							id: contract2.id,
+							type: contract2.type,
+						},
+					},
+				},
+			);
+
+			expect((linkContract1 as any).data.from.id).toBe(
+				(linkContract2 as any).data.from.id,
+			);
+			expect((linkContract1 as any).data.to.id).toBe(
+				(linkContract2 as any).data.to.id,
+			);
+		});
+
+		it('should not add a link if not inserting a contract with a target', async () => {
+			const contract1 = await insertCardContract();
+
+			await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					type: 'card@1.0.0',
+					data: {
+						foo: contract1.id,
+					},
+				},
+			);
+
+			const results = await ctx.kernel.query(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					type: 'object',
+					required: ['type'],
+					additionalProperties: true,
+					properties: {
+						type: {
+							type: 'string',
+							const: 'link',
+						},
+					},
+				},
+			);
+
+			expect(results).toEqual([]);
+		});
+
+		it('.insertContract() should not insert a link if any of the two target contracts does not exist', async () => {
+			await expect(
+				ctx.kernel.insertContract(ctx.logContext, ctx.kernel.adminSession()!, {
+					slug: `link-${testUtils.generateRandomSlug()}-is-attached-to-${testUtils.generateRandomSlug()}`,
+					name: 'is attached to',
+					type: 'link@1.0.0',
+					version: '1.0.0',
+					data: {
+						inverseName: 'has attached',
+						from: {
+							id: testUtils.generateRandomId(),
+							type: 'card@1.0.0',
+						},
+						to: {
+							id: testUtils.generateRandomId(),
+							type: 'card@1.0.0',
+						},
+					},
+				}),
+			).rejects.toThrow(errors.JellyfishNoLinkTarget);
+		});
+
+		it('should not be able to create a link between two valid contracts if there is no relationship between their types', async () => {
+			const contract1 = await insertCardContract();
+
+			const contract2 = await insertCardContract();
+
+			await expect(
+				ctx.kernel.insertContract(ctx.logContext, ctx.kernel.adminSession()!, {
+					slug: `link-${contract1.slug}-is-xxx-invalid-xxx-to-${contract2.slug}`,
+					type: 'link@1.0.0',
+					name: 'is xxx-invalid-xxx to',
+					data: {
+						inverseName: 'has xxx-invalid-xxx element',
+						from: {
+							id: contract1.id,
+							type: contract1.type,
+						},
+						to: {
+							id: contract2.id,
+							type: contract2.type,
+						},
+					},
+				}),
+			).rejects.toThrow(errors.JellyfishUnknownRelationship);
+		});
+
+		it('should be able to create a link between two valid contracts if there is a "to wildcard" type relationship', async () => {
+			const contract1 = await insertCardContract();
+
+			const contract2 = await insertCardContract();
+
+			await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `relationship-card-is-xxx-card-to-wildcard-xxx-to-card`,
+					type: 'relationship@1.0.0',
+					name: 'is xxx-card-to-wildcard-xxx to',
+					data: {
+						inverseName: 'has xxx-card-to-wildcard-xxx element',
+						title: 'Left',
+						inverseTitle: 'Right',
+						from: {
+							type: 'card',
+						},
+						to: {
+							type: '*',
+						},
+					},
+				},
+			);
+
+			const linkContract = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `link-${contract1.slug}-is-linked-to-${contract2.slug}`,
+					type: 'link@1.0.0',
+					version: '1.0.0',
+					name: 'is xxx-card-to-wildcard-xxx to',
+					data: {
+						inverseName: 'has xxx-card-to-wildcard-xxx element',
+						from: {
+							id: contract1.id,
+							type: contract1.type,
+						},
+						to: {
+							id: contract2.id,
+							type: contract2.type,
+						},
+					},
+				},
+			);
+
+			const element = await ctx.kernel.getContractById(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				linkContract.id,
+			);
+
+			assert(element !== null);
+		});
+
+		it('should be able to create a link between two valid contracts if there is a "from wildcard" type relationship', async () => {
+			const contract1 = await insertCardContract();
+
+			const contract2 = await insertCardContract();
+
+			await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `relationship-card-is-xxx-wildcard-to-card-xxx-to-card`,
+					type: 'relationship@1.0.0',
+					name: 'is xxx-wildcard-to-card-xxx to',
+					data: {
+						inverseName: 'has xxx-wildcard-to-card-xxx element',
+						title: 'Left',
+						inverseTitle: 'Right',
+						from: {
+							type: '*',
+						},
+						to: {
+							type: 'card',
+						},
+					},
+				},
+			);
+
+			const linkContract = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `link-${contract1.slug}-is-linked-to-${contract2.slug}`,
+					type: 'link@1.0.0',
+					version: '1.0.0',
+					name: 'is xxx-wildcard-to-card-xxx to',
+					data: {
+						inverseName: 'has xxx-wildcard-to-card-xxx element',
+						from: {
+							id: contract1.id,
+							type: contract1.type,
+						},
+						to: {
+							id: contract2.id,
+							type: contract2.type,
+						},
+					},
+				},
+			);
+
+			const element = await ctx.kernel.getContractById(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				linkContract.id,
+			);
+
+			assert(element !== null);
+		});
+
+		it('should be able to create a link between two valid contracts if there is a unversioned type relationship', async () => {
+			const contract1 = await insertCardContract();
+
+			const contract2 = await insertCardContract();
+
+			await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `relationship-card-is-xxx-versioned-to-card-xxx-to-card`,
+					type: 'relationship@1.0.0',
+					name: 'is xxx-versioned-to-card-xxx to',
+					data: {
+						inverseName: 'has xxx-versioned-to-card-xxx element',
+						title: 'Left',
+						inverseTitle: 'Right',
+						from: {
+							type: 'card@1.0.0',
+						},
+						to: {
+							type: 'card',
+						},
+					},
+				},
+			);
+
+			const linkContract = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `link-${contract1.slug}-is-linked-to-${contract2.slug}`,
+					type: 'link@1.0.0',
+					version: '1.0.0',
+					name: 'is xxx-versioned-to-card-xxx to',
+					data: {
+						inverseName: 'has xxx-versioned-to-card-xxx element',
+						from: {
+							id: contract1.id,
+							type: contract1.type,
+						},
+						to: {
+							id: contract2.id,
+							type: contract2.type,
+						},
+					},
+				},
+			);
+
+			const element = await ctx.kernel.getContractById(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				linkContract.id,
+			);
+
+			assert(element !== null);
+		});
+
+		it('should be able to create a link between two valid contracts with a relationship defined from inverseName to name', async () => {
+			const contract1 = await insertCardContract();
+
+			const contract2 = await insertCardContract();
+
+			await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `relationship-card-is-xxx-forward-xxx-to-card`,
+					type: 'relationship@1.0.0',
+					name: 'is xxx-forward-xxx to',
+					data: {
+						inverseName: 'is xxx-reverse-xxx to',
+						title: 'Left',
+						inverseTitle: 'Right',
+						from: {
+							type: 'card',
+						},
+						to: {
+							type: 'card',
+						},
+					},
+				},
+			);
+
+			const linkContract = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `link-${contract1.slug}-is-linked-to-${contract2.slug}`,
+					type: 'link@1.0.0',
+					version: '1.0.0',
+					name: 'is xxx-reverse-xxx to',
+					data: {
+						inverseName: 'is xxx-forward-xxx to',
+						from: {
+							id: contract1.id,
+							type: contract1.type,
+						},
+						to: {
+							id: contract2.id,
+							type: contract2.type,
+						},
+					},
+				},
+			);
+
+			const element = await ctx.kernel.getContractById(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				linkContract.id,
+			);
+
+			assert(element !== null);
+		});
+
+		it('should be able to create a link from a concrete type to the any type', async () => {
+			const createContract = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					id: uuid(),
+					type: 'card@1.0.0',
+				},
+			);
+
+			const supportThreadContract = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					id: uuid(),
+					type: 'card@1.0.0',
+				},
+			);
+
+			const relationship = await ctx.kernel.replaceContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `relationship-card-forwards-to-any`,
+					type: 'relationship@1.0.0',
+					name: 'forwards to',
+					data: {
+						inverseName: 'is forwarded by',
+						title: 'Card',
+						inverseTitle: 'Destination',
+						from: {
+							type: 'card@1.0.0',
+						},
+						to: {
+							type: '*',
+						},
+					},
+				},
+			);
+
+			assert(createContract !== null);
+			assert(supportThreadContract !== null);
+			assert(relationship !== null);
+
+			const linkContract = await ctx.kernel.insertContract(
+				ctx.logContext,
+				ctx.kernel.adminSession()!,
+				{
+					slug: `link-${createContract.slug}-forwards-to-${supportThreadContract.slug}`,
+					type: 'link@1.0.0',
+					version: '1.0.0',
+					name: 'forwards to',
+					data: {
+						inverseName: 'is forwarded by',
+						from: {
+							id: createContract.id,
+							type: createContract.type,
+						},
+						to: {
+							id: supportThreadContract.id,
+							type: supportThreadContract.type,
+						},
+					},
+				},
+			);
+			assert(linkContract !== null);
+		});
+	});
+});
+
+async function insertCardContract() {
+	return ctx.kernel.insertContract(ctx.logContext, ctx.kernel.adminSession()!, {
+		type: 'card@1.0.0',
+	});
+}
+
+async function upsertRelationshipCardIsAttachedTo() {
+	return ctx.kernel.replaceContract(
+		ctx.logContext,
+		ctx.kernel.adminSession()!,
+		{
+			slug: `relationship-card-is-attached-to-card`,
+			type: 'relationship@1.0.0',
+			name: 'is attached to',
+			data: {
+				inverseName: 'has attached element',
+				title: 'Attachment',
+				inverseTitle: 'Container',
+				from: {
+					type: 'card@1.0.0',
+				},
+				to: {
+					type: 'card@1.0.0',
+				},
+			},
+		},
+	);
+}
+
+async function upsertRelationshipIsLinkedTo() {
+	return ctx.kernel.replaceContract(
+		ctx.logContext,
+		ctx.kernel.adminSession()!,
+		{
+			slug: `relationship-card-is-linked-to-card`,
+			type: 'relationship@1.0.0',
+			name: 'is linked to',
+			data: {
+				inverseName: 'is linked to',
+				title: 'LeftCard',
+				inverseTitle: 'RightCard',
+				from: {
+					type: 'card',
+				},
+				to: {
+					type: 'card',
+				},
+			},
+		},
+	);
+}

--- a/test/integration/kernel.spec.ts
+++ b/test/integration/kernel.spec.ts
@@ -12,6 +12,7 @@ let ctx: testUtils.TestContext;
 
 beforeAll(async () => {
 	ctx = await testUtils.newContext();
+	await createRelationships();
 });
 
 afterAll(async () => {
@@ -2222,211 +2223,6 @@ describe('Kernel', () => {
 					contract,
 				),
 			).rejects.toThrow(errors.JellyfishElementAlreadyExists);
-		});
-
-		it('should be able to create a link between two valid contracts', async () => {
-			const contract1 = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					type: 'card@1.0.0',
-				},
-			);
-
-			const contract2 = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					type: 'card@1.0.0',
-				},
-			);
-
-			const linkContract = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					slug: `link-${contract1.slug}-is-attached-to-${contract2.slug}`,
-					type: 'link@1.0.0',
-					name: 'is attached to',
-					data: {
-						inverseName: 'has attached element',
-						from: {
-							id: contract1.id,
-							type: contract1.type,
-						},
-						to: {
-							id: contract2.id,
-							type: contract2.type,
-						},
-					},
-				},
-			);
-
-			const element = await ctx.kernel.getContractById(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				linkContract.id,
-			);
-
-			assert(element !== null);
-
-			expect(element.data.from).not.toBe(element.data.to);
-		});
-
-		it('should be able to create a direction-less link between two valid contracts', async () => {
-			const contract1 = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					type: 'card@1.0.0',
-				},
-			);
-
-			const contract2 = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					type: 'card@1.0.0',
-				},
-			);
-
-			const linkContract = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					slug: `link-${contract1.slug}-is-linked-to-${contract2.slug}`,
-					type: 'link@1.0.0',
-					name: 'is linked to',
-					data: {
-						inverseName: 'is linked to',
-						from: {
-							id: contract1.id,
-							type: contract1.type,
-						},
-						to: {
-							id: contract2.id,
-							type: contract2.type,
-						},
-					},
-				},
-			);
-
-			const element = await ctx.kernel.getContractById(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				linkContract.id,
-			);
-			assert(element !== null);
-			expect(element.data.from).not.toBe(element.data.to);
-			expect(element.name).toBe(element.data.inverseName);
-		});
-
-		it('should be able to create two different links between two valid contracts', async () => {
-			const contract1 = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					type: 'card@1.0.0',
-				},
-			);
-
-			const contract2 = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					type: 'card@1.0.0',
-				},
-			);
-
-			const linkContract1 = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					slug: `link-${contract1.slug}-is-linked-to-${contract2.slug}`,
-					type: 'link@1.0.0',
-					version: '1.0.0',
-					name: 'is linked to',
-					data: {
-						inverseName: 'has been linked to',
-						from: {
-							id: contract1.id,
-							type: contract1.type,
-						},
-						to: {
-							id: contract2.id,
-							type: contract2.type,
-						},
-					},
-				},
-			);
-
-			const linkContract2 = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					slug: `link-${contract1.slug}-is-attached-to-${contract2.slug}`,
-					type: 'link@1.0.0',
-					version: '1.0.0',
-					name: 'is attached to',
-					data: {
-						inverseName: 'has attached element',
-						from: {
-							id: contract1.id,
-							type: contract1.type,
-						},
-						to: {
-							id: contract2.id,
-							type: contract2.type,
-						},
-					},
-				},
-			);
-
-			expect((linkContract1 as any).data.from.id).toBe(
-				(linkContract2 as any).data.from.id,
-			);
-			expect((linkContract1 as any).data.to.id).toBe(
-				(linkContract2 as any).data.to.id,
-			);
-		});
-
-		it('should not add a link if not inserting a contract with a target', async () => {
-			const contract1 = await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					type: 'card@1.0.0',
-				},
-			);
-
-			await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					type: 'card@1.0.0',
-					data: {
-						foo: contract1.id,
-					},
-				},
-			);
-
-			const results = await ctx.kernel.query(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					type: 'object',
-					required: ['type'],
-					additionalProperties: true,
-					properties: {
-						type: {
-							type: 'string',
-							const: 'link',
-						},
-					},
-				},
-			);
-
-			expect(results).toEqual([]);
 		});
 
 		it('.insertContract() read access on a property should not allow to write other properties', async () => {
@@ -5223,7 +5019,7 @@ describe('Kernel', () => {
 					version: '1.0.0',
 					name: 'is child of',
 					data: {
-						inverseName: 'owns',
+						inverseName: 'has child',
 						from: {
 							id: child.id,
 							type: child.type,
@@ -5245,7 +5041,7 @@ describe('Kernel', () => {
 					version: '1.0.0',
 					name: 'is child of',
 					data: {
-						inverseName: 'owns',
+						inverseName: 'has child',
 						from: {
 							id: grandchild.id,
 							type: grandchild.type,
@@ -8505,3 +8301,134 @@ describe('Kernel', () => {
 		});
 	});
 });
+
+// Create the relationships which are not already part of the kernel
+async function createRelationships() {
+	const relSpecs: any[] = [
+		{
+			fromVersionedType: 'user',
+			toVersionedType: 'org',
+			name: 'is member of',
+			inverseName: 'has member',
+			title: 'User',
+			inverseTitle: 'Organization',
+		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: 'org',
+			name: 'is part of',
+			inverseName: 'has member',
+			title: 'Card',
+			inverseTitle: 'Organization',
+		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: 'card',
+			name: 'is attached to',
+			inverseName: 'has attached element',
+			title: 'Attachment',
+			inverseTitle: 'Attachment',
+		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: 'card',
+			name: 'is linked to',
+			inverseName: 'has link',
+			title: 'Link',
+			inverseTitle: 'Link',
+		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: 'card',
+			name: 'is child of',
+			inverseName: 'has child', // It is defined like this in tests above
+			title: 'Card',
+			inverseTitle: 'Card',
+		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: 'card',
+			name: 'is appended to',
+			inverseName: 'has appended element',
+			title: 'Card',
+			inverseTitle: 'Card',
+		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: 'card',
+			name: 'is owned by',
+			inverseName: 'owns',
+			title: 'Card',
+			inverseTitle: 'Owner',
+		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: 'card',
+			name: 'works at',
+			inverseName: 'has worker',
+			title: 'Worker',
+			inverseTitle: 'Workplace',
+		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: 'card',
+			name: 'believes in',
+			inverseName: 'is believed by',
+			title: 'Believer',
+			inverseTitle: 'Deity',
+		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: 'card',
+			name: 'reports to',
+			inverseName: 'receives reports from',
+			title: 'Reporter',
+			inverseTitle: 'Manager',
+		},
+	];
+
+	const relContracts = relSpecs.map((spec) => {
+		const fromType = spec.fromVersionedType.split('@')[0];
+		const toType = spec.toVersionedType.split('@')[0];
+		const dashedName = _.kebabCase(spec.name);
+		return {
+			slug: `relationship-${fromType}-${dashedName}-${toType}`,
+			type: 'relationship@1.0.0',
+			name: spec.name,
+			data: {
+				inverseName: spec.inverseName,
+				title: spec.title,
+				inverseTitle: spec.inverseTitle,
+				from: {
+					type: spec.fromVersionedType,
+				},
+				to: {
+					type: spec.toVersionedType,
+				},
+			},
+		};
+	});
+
+	const inKernelRelationshipsCount = ctx.kernel.getRelationships().length;
+
+	const createdContracts = await Promise.all(
+		relContracts.map((rc) =>
+			ctx.kernel.insertContract(ctx.logContext, ctx.kernel.adminSession()!, rc),
+		),
+	);
+
+	createdContracts.forEach((cc) => assert(cc !== null));
+
+	// wait until all relationships are loaded into the kernel
+	await ctx.retry(
+		() => {
+			return ctx.kernel.getRelationships();
+		},
+		(relationships: RelationshipContract[]) => {
+			return (
+				relationships.length >=
+				createdContracts.length + inKernelRelationshipsCount
+			);
+		},
+	);
+}


### PR DESCRIPTION
This is the PR for the [relationship contract" JIP](https://jel.ly.fish/improvement-jip-link-constraints-using-relationship-contract-f3666fd0-e5d6-4ca4-9fa8-73959e72e7c3)

It adds logic to the kernel to validate links on inserts and upserts: each link must be backed by a relationship contract.

- [x] Validate the overall approach
- [x] In order to validate the idea and discover which kind of links are actually created, this initial version includes a basic set of relationships and also relationships that back the links created from jellyfish modules. This last set will be moved to jellyfish.
- [x] Optimize the implementation. See `FIXME`s and `TODO`s
- [x] Use a cache to avoid querying the relationships on each link insert

Testing in:
- https://github.com/product-os/jellyfish-plugin-default/pull/1157
- https://github.com/product-os/jellyfish-plugin-product-os/pull/815
- https://github.com/product-os/jellyfish-plugin-github/pull/890
- https://github.com/product-os/jellyfish-plugin-channels/pull/655
- https://github.com/product-os/jellyfish-plugin-typeform/pull/898