### PR TITLE
Split the `authentication` contract into two

### DIFF
--- a/lib/contracts/authentication-oauth.ts
+++ b/lib/contracts/authentication-oauth.ts
@@ -1,21 +1,22 @@
-export const authentication = {
-	slug: 'authentication',
+export const authenticationOauth = {
+	slug: 'authentication-oauth',
 	type: 'type@1.0.0',
-	name: 'Authentication Details',
+	name: 'OAuth Authentication Details',
 	data: {
 		schema: {
 			type: 'object',
 			properties: {
 				slug: {
 					type: 'string',
-					pattern: '^authentication-[a-z0-9-]+$',
+					pattern: '^authentication-oauth-[a-z0-9-]+$',
 				},
 				data: {
 					type: 'object',
+					required: ['actorId', 'oauth'],
 					properties: {
-						hash: {
+						actorId: {
 							type: 'string',
-							minLength: 1,
+							format: 'uuid',
 						},
 						oauth: {
 							description: 'Linked accounts',

--- a/lib/contracts/authentication-password.ts
+++ b/lib/contracts/authentication-password.ts
@@ -1,0 +1,30 @@
+export const authenticationPassword = {
+	slug: 'authentication-password',
+	type: 'type@1.0.0',
+	name: 'Password Authentication Details',
+	data: {
+		schema: {
+			type: 'object',
+			properties: {
+				slug: {
+					type: 'string',
+					pattern: '^authentication-password-[a-z0-9-]+$',
+				},
+				data: {
+					type: 'object',
+					required: ['actorId', 'hash'],
+					properties: {
+						actorId: {
+							type: 'string',
+							format: 'uuid',
+						},
+						hash: {
+							type: 'string',
+							minLength: 1,
+						},
+					},
+				},
+			},
+		},
+	},
+};

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -1,5 +1,6 @@
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
-import { authentication } from './authentication';
+import { authenticationOauth } from './authentication-oauth';
+import { authenticationPassword } from './authentication-password';
 import { card } from './card';
 import { error } from './error';
 import { event } from './event';
@@ -23,27 +24,28 @@ import { userSettings } from './user-settings';
 import { view } from './view';
 
 const contracts = [
+	authenticationOauth,
+	authenticationPassword,
 	card,
-	role,
-	org,
-	event,
 	error,
+	event,
 	link,
 	loop,
-	session,
-	type,
-	userAdmin,
-	user,
+	oauthClient,
+	oauthProvider,
+	org,
+	role,
 	roleUserAdmin,
 	roleUserCommunity,
 	roleUserGuest,
 	roleUserOperator,
 	roleUserTest,
-	view,
-	oauthProvider,
-	oauthClient,
-	authentication,
+	session,
+	type,
+	user,
+	userAdmin,
 	userSettings,
+	view,
 ];
 
 export const CONTRACTS = contracts.reduce<{

--- a/lib/contracts/role-user-community.ts
+++ b/lib/contracts/role-user-community.ts
@@ -147,13 +147,23 @@ export const roleUserCommunity: RoleContractDefinition = {
 				},
 				{
 					properties: {
-						id: {
-							const: {
-								$eval: 'user.id',
-							},
-						},
 						type: {
-							enum: ['authentication@1.0.0', 'user-settings@1.0.0'],
+							enum: [
+								'authentication-oauth@1.0.0',
+								'authentication-password@1.0.0',
+								'user-settings@1.0.0',
+							],
+						},
+						data: {
+							type: 'object',
+							required: ['actorId'],
+							properties: {
+								actorId: {
+									const: {
+										$eval: 'user.id',
+									},
+								},
+							},
 						},
 					},
 				},

--- a/lib/contracts/user-settings.ts
+++ b/lib/contracts/user-settings.ts
@@ -12,7 +12,12 @@ export const userSettings = {
 				},
 				data: {
 					type: 'object',
+					required: ['actorId'],
 					properties: {
+						actorId: {
+							type: 'string',
+							format: 'uuid',
+						},
 						type: {
 							type: 'string',
 						},

--- a/lib/kernel.ts
+++ b/lib/kernel.ts
@@ -425,7 +425,8 @@ export class Kernel {
 		await Promise.all([
 			unsafeUpsert(CONTRACTS.type),
 			unsafeUpsert(CONTRACTS.session),
-			unsafeUpsert(CONTRACTS.authentication),
+			unsafeUpsert(CONTRACTS['authentication-oauth']),
+			unsafeUpsert(CONTRACTS['authentication-password']),
 			unsafeUpsert(CONTRACTS.user),
 			unsafeUpsert(CONTRACTS['user-settings']),
 			unsafeUpsert(CONTRACTS['role-user-admin']),


### PR DESCRIPTION
Two new types: `authentication-password` and `authentication-oauth`.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>