### PR TITLE
Set sane statement and query timeouts for postgres

### DIFF
--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -199,8 +199,8 @@ export interface PostgresBackendOptions {
 }
 
 const defaultPgOptions: Partial<PostgresBackendOptions> = {
-	// statement_timeout: undefined,
-	// query_timeout: undefined,
+	statement_timeout: 30 * 1000,
+	query_timeout: 30 * 1000,
 	idleTimeoutMillis: 60 * 1000,
 	connectionTimeoutMillis: 30 * 1000,
 	keepAlive: true,


### PR DESCRIPTION
Previously, the statement and query timeouts were not set and just ran
on the default of 0, which is no timeout. This changes it to 30s.
See https://node-postgres.com/api/client

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>