### PR TITLE
Streams: Add checking for contract type in `anyOf` expression

### DIFF
--- a/lib/backend/postgres/streams.ts
+++ b/lib/backend/postgres/streams.ts
@@ -283,14 +283,22 @@ export class Stream extends EventEmitter {
 		if (schema instanceof Object) {
 			if (_.has(schema, ['properties', 'type', 'const'])) {
 				this.cardTypes = [(schema.properties!.type as any).const.split('@')[0]];
-			}
-			if (_.has(schema, ['properties', 'type', 'enum'])) {
+			} else if (_.has(schema, ['properties', 'type', 'enum'])) {
 				const deversionedTypes = (schema.properties!.type as any).enum.map(
 					(typeName: string) => {
 						return typeName.split('@')[0];
 					},
 				);
 				this.cardTypes = deversionedTypes;
+			} else if (_.has(schema, ['properties', 'type', 'anyOf'])) {
+				const deversionedTypes = (schema.properties!.type as any).anyOf.map(
+					(subSchema: JsonSchema) => {
+						return typeof subSchema === 'boolean'
+							? null
+							: (subSchema?.const as string).split('@')[0];
+					},
+				);
+				this.cardTypes = _.compact(deversionedTypes);
 			}
 		}
 		this.streamQuery = Context.prepareQuery(


### PR DESCRIPTION
This allows more stream results to be quickly rejected

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>