### PR TITLE
Do not create `authentication-password` contracts for users that don't have what looks like a valid hash

### DIFF
--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -733,7 +733,7 @@ export class PostgresBackend implements Database {
 				options,
 			);
 
-			if (userContract.data.hash && userContract.data.hash !== 'PASSWORDLESS') {
+			if (userContract.data.hash && userContract.data.hash.charAt(0) === '$') {
 				const authenticationContract = await this.upsertObject(
 					context,
 					{


### PR DESCRIPTION
Setting the hash to an invalid hash disables login indirectly. This is usually done by setting the hash to the constant `PASSWORDLESS` but the same effect can be achieved with other strings. Some tests and a few contracts on live do this so we need to check if the hash at least looks valid.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>