### PR TITLE
Refactor role permission schemas

### DIFF
--- a/lib/contracts/role-user-community.ts
+++ b/lib/contracts/role-user-community.ts
@@ -11,183 +11,66 @@ export const roleUserCommunity: RoleContractDefinition = {
 			required: ['active'],
 			properties: {
 				active: {
-					type: 'boolean',
 					const: true,
 				},
 			},
-			anyOf: [
-				{
-					type: 'object',
-					additionalProperties: true,
-					required: ['slug', 'type'],
-					properties: {
-						slug: {
-							type: 'string',
-							not: {
-								enum: ['action-create-user'],
-							},
-						},
-						type: {
-							type: 'string',
-							not: {
+			not: {
+				anyOf: [
+					{
+						required: ['slug'],
+						properties: {
+							slug: {
 								enum: [
-									'action-request@1.0.0',
-									'create@1.0.0',
-									'event@1.0.0',
-									'external-event@1.0.0',
-									'role@1.0.0',
-									'session@1.0.0',
-									'type@1.0.0',
-									'user@1.0.0',
-									'view@1.0.0',
-									'password-reset@1.0.0',
-									'first-time-login@1.0.0',
-								],
-							},
-						},
-					},
-				},
-				{
-					type: 'object',
-					required: ['slug', 'type'],
-					additionalProperties: true,
-					properties: {
-						slug: {
-							not: {
-								enum: [
+									'action-create-user',
 									'action',
 									'event',
 									'external-event',
-									'role',
 									'first-time-login',
+									'role',
 									'triggered-action',
+									'view-active-triggered-actions',
+									'view-active',
+									'view-non-executed-action-requests',
 								],
 							},
 						},
-						type: {
-							type: 'string',
-							const: 'type@1.0.0',
-						},
 					},
-				},
-				{
-					type: 'object',
-					description:
-						'User can view their own execute, session, web-push-subscription and view cards',
-					additionalProperties: true,
-					required: ['data', 'type'],
-					properties: {
-						type: {
-							type: 'string',
-							enum: [
-								'view@1.0.0',
-								'session@1.0.0',
-								'web-push-subscription@1.0.0',
-								'execute@1.0.0',
-							],
-						},
-						data: {
-							type: 'object',
-							required: ['actor'],
-							additionalProperties: true,
-							properties: {
-								actor: {
-									type: 'string',
-									const: {
-										$eval: 'user.id',
-									},
-								},
+					{
+						required: ['type'],
+						properties: {
+							type: {
+								enum: [
+									'action-request@1.0.0',
+									'event@1.0.0',
+									'external-event@1.0.0',
+									'first-time-login@1.0.0',
+									'password-reset@1.0.0',
+									'role@1.0.0',
+								],
 							},
 						},
 					},
-				},
-				{
-					type: 'object',
-					additionalProperties: true,
-					required: ['slug', 'type', 'data'],
-					properties: {
-						slug: {
-							type: 'string',
-							const: {
-								$eval: 'user.slug',
+					{
+						description:
+							'User can view their own execute, session, web-push-subscription and view cards',
+						required: ['type', 'data'],
+						properties: {
+							type: {
+								enum: [
+									'execute@1.0.0',
+									'session@1.0.0',
+									'view@1.0.0',
+									'web-push-subscription@1.0.0',
+								],
 							},
-						},
-						type: {
-							type: 'string',
-							const: 'user@1.0.0',
-						},
-						data: {
-							type: 'object',
-							additionalProperties: false,
-							properties: {
-								status: {
+							data: {
+								not: {
 									type: 'object',
-									additionalProperties: true,
-								},
-								email: {
-									type: ['string', 'array'],
-								},
-								hash: {
-									type: 'string',
-								},
-								avatar: {
-									type: ['string', 'null'],
-								},
-								oauth: {
-									type: 'object',
-									additionalProperties: true,
-								},
-								profile: {
-									type: 'object',
-									additionalProperties: true,
-								},
-							},
-						},
-					},
-				},
-				{
-					properties: {
-						type: {
-							enum: [
-								'authentication-oauth@1.0.0',
-								'authentication-password@1.0.0',
-								'user-settings@1.0.0',
-							],
-						},
-						data: {
-							type: 'object',
-							required: ['actorId'],
-							properties: {
-								actorId: {
-									const: {
-										$eval: 'user.id',
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					type: 'object',
-					description: "User can view create cards that don't create users",
-					additionalProperties: true,
-					required: ['data', 'type'],
-					properties: {
-						type: {
-							type: 'string',
-							const: 'create@1.0.0',
-						},
-						data: {
-							type: 'object',
-							additionalProperties: true,
-							properties: {
-								payload: {
-									type: 'object',
+									required: ['actor'],
 									properties: {
-										type: {
-											type: 'string',
-											not: {
-												enum: ['user@1.0.0', 'user'],
+										actor: {
+											const: {
+												$eval: 'user.id',
 											},
 										},
 									},
@@ -195,96 +78,123 @@ export const roleUserCommunity: RoleContractDefinition = {
 							},
 						},
 					},
-				},
-				{
-					type: 'object',
-					additionalProperties: true,
-					required: ['slug', 'type', 'data'],
-					properties: {
-						type: {
-							type: 'string',
-							const: 'view@1.0.0',
-						},
-						slug: {
-							type: 'string',
-							not: {
-								enum: [
-									'view-active',
-									'view-active-triggered-actions',
-									'view-non-executed-action-requests',
-								],
-							},
-						},
-						data: {
-							type: 'object',
-							additionalProperties: true,
-						},
-					},
-				},
-				{
-					type: 'object',
-					additionalProperties: true,
-					required: ['id', 'type', 'data', 'slug'],
-					properties: {
-						id: {
-							type: 'string',
-						},
-						slug: {
-							type: 'string',
-							not: {
-								enum: ['user-admin', 'user-guest'],
-							},
-						},
-						type: {
-							type: 'string',
-							const: 'user@1.0.0',
-						},
-						data: {
-							type: 'object',
-							additionalProperties: false,
-							properties: {
-								status: {
-									type: 'object',
-									additionalProperties: true,
+					{
+						required: ['slug', 'type', 'data'],
+						properties: {
+							slug: {
+								const: {
+									$eval: 'user.slug',
 								},
-								email: {
-									type: ['string', 'array'],
-								},
-								profile: {
+							},
+							type: {
+								const: 'user@1.0.0',
+							},
+							data: {
+								not: {
 									type: 'object',
 									additionalProperties: false,
 									properties: {
-										name: {
-											type: 'object',
-										},
-										about: {
-											type: 'object',
-										},
-										birthday: {
-											type: 'string',
-										},
-										startDate: {
-											type: 'string',
-										},
-										country: {
-											type: 'string',
-										},
-										city: {
-											type: 'string',
-										},
-										timezone: {
-											type: 'string',
-										},
+										avatar: true,
+										email: true,
+										hash: true,
+										oauth: true,
+										profile: true,
+										status: true,
 									},
-								},
-								avatar: {
-									type: ['string', 'null'],
 								},
 							},
 						},
 					},
-				},
-			],
+					{
+						required: ['type', 'data'],
+						properties: {
+							type: {
+								enum: [
+									'authentication-oauth@1.0.0',
+									'authentication-password@1.0.0',
+									'user-settings@1.0.0',
+								],
+							},
+							data: {
+								not: {
+									type: 'object',
+									required: ['actorId'],
+									properties: {
+										actorId: {
+											const: {
+												$eval: 'user.id',
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						description: "User can view create cards that don't create users",
+						required: ['type', 'data'],
+						properties: {
+							type: {
+								const: 'create@1.0.0',
+							},
+							data: {
+								not: {
+									type: 'object',
+									properties: {
+										payload: {
+											type: 'object',
+											properties: {
+												type: {
+													not: {
+														enum: ['user@1.0.0', 'user'],
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						required: ['slug', 'type', 'data'],
+						properties: {
+							slug: {
+								not: {
+									enum: ['user-admin', 'user-guest'],
+								},
+							},
+							type: {
+								const: 'user@1.0.0',
+							},
+							data: {
+								not: {
+									type: 'object',
+									additionalProperties: false,
+									properties: {
+										avatar: true,
+										email: true,
+										profile: {
+											type: 'object',
+											additionalProperties: false,
+											properties: {
+												name: true,
+												about: true,
+												birthday: true,
+												startDate: true,
+												country: true,
+												city: true,
+												timezone: true,
+											},
+										},
+										status: true,
+									},
+								},
+							},
+						},
+					},
+				],
+			},
 		},
 	},
 };

--- a/lib/contracts/role-user-guest.ts
+++ b/lib/contracts/role-user-guest.ts
@@ -9,16 +9,13 @@ export const roleUserGuest: RoleContractDefinition = {
 		read: {
 			type: 'object',
 			required: ['slug', 'type'],
-			additionalProperties: true,
 			properties: {
 				slug: {
-					type: 'string',
 					const: {
 						$eval: 'user.slug',
 					},
 				},
 				type: {
-					type: 'string',
 					const: 'user@1.0.0',
 				},
 			},

--- a/lib/contracts/role-user-operator.ts
+++ b/lib/contracts/role-user-operator.ts
@@ -11,42 +11,26 @@ export const roleUserOperator: RoleContractDefinition = {
 			anyOf: [
 				{
 					type: 'object',
-					additionalProperties: true,
 					required: ['slug'],
 					properties: {
 						slug: {
-							type: 'string',
-							enum: ['first-time-login', 'action-create-user'],
+							enum: ['action-create-user', 'first-time-login'],
 						},
 					},
 				},
 				{
-					type: 'object',
 					description:
-						"User can see other user's roles (except for user-admin and user-guest)",
-					additionalProperties: true,
-					required: ['data', 'type', 'slug'],
+						'User can see other users (except for user-admin and user-guest)',
+					type: 'object',
+					required: ['type', 'slug'],
 					properties: {
 						slug: {
-							type: 'string',
 							not: {
 								enum: ['user-admin', 'user-guest'],
 							},
 						},
 						type: {
-							type: 'string',
 							const: 'user@1.0.0',
-						},
-						data: {
-							type: 'object',
-							properties: {
-								roles: {
-									type: 'array',
-									items: {
-										type: 'string',
-									},
-								},
-							},
 						},
 					},
 				},

--- a/lib/contracts/role-user-test.ts
+++ b/lib/contracts/role-user-test.ts
@@ -6,8 +6,6 @@ export const roleUserTest: RoleContractDefinition = {
 	type: 'role@1.0.0',
 	markers: [],
 	data: {
-		read: {
-			type: 'object',
-		},
+		read: {},
 	},
 };

--- a/test/integration/kernel.spec.ts
+++ b/test/integration/kernel.spec.ts
@@ -1617,10 +1617,7 @@ describe('Kernel', () => {
 
 		it('should apply patch for users that satisfy markers', async () => {
 			const org = await ctx.createOrg(testUtils.generateRandomId());
-			const user = await ctx.createUser(
-				testUtils.generateRandomId(),
-				testUtils.generateRandomId(),
-			);
+			const user = await ctx.createUser(testUtils.generateRandomId());
 			await ctx.createLink(user, org, 'is member of', 'has member');
 			const session = await ctx.createSession(user);
 


### PR DESCRIPTION
- Remove redundant `additionalProperties: true` entries.
- Remove constraints that duplicate the contract type definition with no functional reason. These constraints may not only add useless constraints to the underlying database query but also make permissions more brittle as minor changes to the underlying type definition may invalidate permission constraints that are too specific.
- When denying access to specific slugs do it regardless of type. It is technically possible to have multiple contracts with the same slug and different types but the latter is not important. This also helps future-proofing permissions.
- While `role-user-guest`, `role-user-operator`, and `role-user-test` have a deny-by-default policy, `role-user-community` has a allow-by-default policy. It achieves this by having a denylist in disjunction with the allowlist:

```
d || a0 || a1 || ...
```

where `d` is the denylist and `a*` is an entry from the allowlist. While this arrangement works, it allows for a particularly nasty way to shoot our own foot: the denylist must cover each and every entry in the allowlist or otherwise non-covered entries are nullified. For example, if we want to restrict access to `session` contracts:

```js
{
  properties: {
    type: { const: 'session@1.0.0' },
    data: {
      properties: {
        actor: { const: { $eval: 'user.id' } }
      }
    }
  }
}
```

In a deny-by-default scenario this is sufficient to apply the restrictions we want. In a allow-by-default scenario with the denylist in disjunction with the allowlist we are additionary required to add all `session` contracts to the denylist:

```js
{
  properties: {
    type: {
      not: { const: 'session@1.0.0' }
    }
  }
}
```

The footgun is a failure to maintain the denylist and allowlist in sync will silently allow full access to everything the denylist doesn't cover, regardless of what the allowlist contains. And so, security holes are easy to create by minor mistakes. To fix this both lists are now combined with a conjunction:

```
d && (a0 || a1 || ...)
```

That is, access will be granted only when **both** the denylist and allowlist checks pass. This change has two effects:

  - The denylist now only contains the things that are completely inaccessible with no exceptions, considerably simplifying `d`.
  - Each allowlist entry is now completely self-contained. Adding or removing allowlist entries require no changes to the denylist.

To make this approach works we must change how we write allowlist entries slightly so they work in a allow-by-default world. To illustrate the problem assume the following two entries:

```js
anyOf: [
  {
    properties: {
      type: { const: 'session@1.0.0' },
      data: {
        properties: {
          actor: { const: { $eval: 'user.id' } }
        }
      }
    }
  },
  {
    properties: {
      type: { const: 'execute@1.0.0' },
      data: {
        properties: {
          actor: { const: { $eval: 'user.id' } }
        }
      }
    }
  }
]
```

Since we're now using conjunction this `anyOf` must evaluate to `true` on every contract that is not of type `session` or `execute`, which is clearly impossible. To allow for that to happen we have to slightly change how entries are expressed. For that we now use another boolean operator: material implication `p -> t`, where `p` is the precondition and `t` is the test. Material implication does the following operation: if `p` then `t` else `true`. For the above allowlist:

```
((type == 'session@1.0.0') -> (data.actor == user.id)) &&  # If contract is of type `session` then it must be owned by the current user
((type == 'execute@1.0.0') -> (data.actor == user.id))     # If contract is of type `execute` then it must be owned by the current user
```

Unfortunately we can't express `p -> t` directly with JSON Schema and have to use the equivalent expression `!p || t` instead. Simplifying the full expression with the denylist we get:

```
!(!d || (p0 && !t0) || (p1 && !t1) || ...)
```

In JSON Schema it looks something like this:

```js
not: {
  anyOf: [
    {
      properties: {
        slug: { const: 'user-admin' }
      }
    },
    {
      properties: {
        type: { const: 'session@1.0.0' },
        data: {
          properties: {
            actor: { not: { const: { $eval: 'user.id' } } }
          }
        }
      }
    },
    {
      properties: {
        type: { const: 'execute@1.0.0' },
        data: {
          properties: {
            actor: { not: { const: { $eval: 'user.id' } } }
          }
        }
      }
    }
  ]
}
```

Notice:

  - Toplevel `not`.
  - The denylist (first entry inside the `anyOf`) doesn't have a `not`. If the denylist matches the toplevel `not` will invert the result and return `false`.
  - In the allowlist the precondition is unaffected (type check) but the test is negated (ID check).

In practical terms, this change turns the allowlist into a self-contained filterlist, which is a better fit for an allow-by-default-world. This also slightly reduces the amount of checks run by the database.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>