### PR TITLE
Alphabetize interface generation output

### DIFF
--- a/lib/cli/index.ts
+++ b/lib/cli/index.ts
@@ -23,21 +23,8 @@ program
 		'Path to output directory',
 		'lib/types/contracts',
 	)
-	.action((options) => {
-		generateContractInterfaces(options.input, options.output).then(
-			(results) => {
-				const succeeded = _.filter(results, _.identity);
-				console.log(
-					`Generated ${succeeded.length} contract interfaces (${
-						results.length - succeeded.length
-					} failed)`,
-				);
-
-				if (results.length - succeeded.length > 0) {
-					process.exit(1);
-				}
-			},
-		);
+	.action(async (options) => {
+		await generateContractInterfaces(options.input, options.output);
 	});
 
 program.parse();

--- a/lib/types/contracts/index.ts
+++ b/lib/types/contracts/index.ts
@@ -16,15 +16,15 @@ export type {
 } from './authentication-password';
 export type { CardContract, CardContractDefinition, CardData } from './card';
 export type {
-	EventContract,
-	EventContractDefinition,
-	EventData,
-} from './event';
-export type {
 	ErrorContract,
 	ErrorContractDefinition,
 	ErrorData,
 } from './error';
+export type {
+	EventContract,
+	EventContractDefinition,
+	EventData,
+} from './event';
 export type { LinkContract, LinkContractDefinition, LinkData } from './link';
 export type { LoopContract, LoopContractDefinition, LoopData } from './loop';
 export type { OrgContract, OrgContractDefinition, OrgData } from './org';


### PR DESCRIPTION
Ensure that compiled TypeScript interface definitions are output
in alphabetized order.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>