### PR TITLE
Fix bug where stream updates don't occur for new links

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+	"singleQuote": true,
+	"trailingComma": "all",
+	"useTabs": true
+}

--- a/test/integration/kernel.spec.ts
+++ b/test/integration/kernel.spec.ts
@@ -7671,7 +7671,7 @@ describe('Kernel', () => {
 				});
 		});
 
-		it.only('should be able to resolve links when a new link is added', (done) => {
+		it('should be able to resolve links when a new link is added', (done) => {
 			const slug = testUtils.generateRandomSlug();
 
 			ctx.kernel
@@ -7768,7 +7768,7 @@ describe('Kernel', () => {
 				});
 		});
 
-		it.only('should be able to resolve links when subsequent links of the same verb are added', async () => {
+		it('should be able to resolve links when subsequent links of the same verb are added', async () => {
 			const slug = testUtils.generateRandomSlug();
 
 			// Create the base contract, and two additional contracts to link to
@@ -7889,6 +7889,9 @@ describe('Kernel', () => {
 				slug,
 				links: {
 					'is attached to': [
+						{
+							slug: contract2.slug,
+						},
 						{
 							slug: contract3.slug,
 						},


### PR DESCRIPTION
This PR fixes a bug where you won't get a stream update when for
multiple links with the same verb. The first link *will* trigger an
update, but any after that do not.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>