### PR TITLE
Don't log entire stream schema on error

### DIFF
--- a/lib/backend/postgres/streams.ts
+++ b/lib/backend/postgres/streams.ts
@@ -230,7 +230,6 @@ export class Stream extends EventEmitter {
 				id,
 				table: streamer.table,
 				message: error.message,
-				schema,
 			});
 		});
 	}


### PR DESCRIPTION
This reduces verbosity of stream errors, making them easier to work with.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>