### PR TITLE
Lucianbuzzo/stream multiplexing

### DIFF
--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -7,6 +7,7 @@ import { performance } from 'perf_hooks';
 import { Pool, PoolClient } from 'pg';
 import * as semver from 'semver';
 import * as skhema from 'skhema';
+import { setTimeout as delay } from 'timers/promises';
 import type { Cache } from '../../cache';
 import { Context, Database, Query, TransactionIsolation } from '../../context';
 import * as errors from '../../errors';
@@ -527,6 +528,9 @@ export class PostgresBackend implements Database {
 		 * Close the main connection pool.
 		 */
 		if (this.pool) {
+			// Allow a small grace period for ongoing transactions to finish before ending the pool.
+			// This is a hack and should be replaced with determinstic approach to draining the pool.
+			await delay(50);
 			context.debug('Disconnecting from database', {
 				databaseName: this.databaseName,
 			});

--- a/lib/backend/postgres/index.ts
+++ b/lib/backend/postgres/index.ts
@@ -566,7 +566,7 @@ export class PostgresBackend implements Database {
 	async insertElement<T extends Contract = Contract>(
 		context: Context,
 		object: Omit<Contract, 'id'> & Partial<Pick<Contract, 'id'>>,
-	) {
+	): Promise<T> {
 		return this.upsertObject<T>(context, object, {
 			replace: false,
 		});
@@ -793,7 +793,10 @@ export class PostgresBackend implements Database {
 				);
 			}
 
-			if (userContract.data.oauth && userContract.data.oauth !== {}) {
+			if (
+				userContract.data.oauth &&
+				Object.keys(userContract.data.oauth).length > 1
+			) {
 				const authenticationContract = await this.upsertObject(
 					context,
 					{

--- a/lib/backend/postgres/links.ts
+++ b/lib/backend/postgres/links.ts
@@ -19,7 +19,7 @@ export const setup = async (
 		// The name of the "cards" table that should be referenced
 		cards: string;
 	},
-) => {
+): Promise<void> => {
 	context.debug('Creating links table', {
 		table: LINK_TABLE,
 		databaseName,

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,7 +1,7 @@
 import * as assert from '@balena/jellyfish-assert';
 import * as logger from '@balena/jellyfish-logger';
 import * as _ from 'lodash';
-import { Notification, PoolClient, QueryConfig } from 'pg';
+import { Notification, PoolClient, QueryConfig, QueryResultRow } from 'pg';
 import * as pgFormat from 'pg-format';
 import * as uuid from 'uuid';
 import * as errors from './errors';
@@ -162,7 +162,8 @@ export class Context {
 		}
 
 		try {
-			return await cbPromise;
+			const result = await cbPromise;
+			return result;
 		} catch (error: unknown) {
 			throw saneError(error);
 		} finally {
@@ -323,7 +324,10 @@ export class Context {
 	/**
 	 * Run a query and return its results.
 	 */
-	public async query<T = any>(query: Query, parameters?: any[]): Promise<T[]> {
+	public async query<T extends QueryResultRow = any>(
+		query: Query,
+		parameters?: any[],
+	): Promise<T[]> {
 		return (
 			await this.withDatabaseConnection((context: Context) => {
 				let textOrConfig: any;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { CONTRACTS } from './contracts';
 import type { JsonSchema, ViewContract } from './types';
 import { getViewContractSchema } from './views';
@@ -14,4 +15,31 @@ export const preprocessQuerySchema = async (
 	}
 
 	return schema as JsonSchema;
+};
+
+export const getSchemaTypes = (schema: JsonSchema): string[] => {
+	let linkSchemaTypes = [];
+	if (typeof schema !== 'boolean') {
+		if (_.has(schema, ['properties', 'type', 'const'])) {
+			linkSchemaTypes = [(schema.properties!.type as any).const.split('@')[0]];
+		} else if (_.has(schema, ['properties', 'type', 'enum'])) {
+			const deversionedTypes = (schema.properties!.type as any).enum.map(
+				(typeName: string) => {
+					return typeName.split('@')[0];
+				},
+			);
+			linkSchemaTypes = deversionedTypes;
+		} else if (_.has(schema, ['properties', 'type', 'anyOf'])) {
+			const deversionedTypes = (schema.properties!.type as any).anyOf.map(
+				(subSchema: JsonSchema) => {
+					return typeof subSchema === 'boolean'
+						? null
+						: (subSchema?.const as string).split('@')[0];
+				},
+			);
+			linkSchemaTypes = _.compact(deversionedTypes);
+		}
+	}
+
+	return linkSchemaTypes;
 };

--- a/test/integration/backend/index.spec.ts
+++ b/test/integration/backend/index.spec.ts
@@ -4785,7 +4785,6 @@ describe('backend', () => {
 				]);
 			});
 
-			console.log(result);
 			expect(result.type).toBe('insert');
 			expect(result.after).toEqual({
 				id: result.id,
@@ -4920,8 +4919,6 @@ describe('backend', () => {
 					},
 				});
 			});
-
-			console.log(result);
 
 			expect(result.type).toBe('update');
 			expect(result.after).toEqual({
@@ -5143,7 +5140,6 @@ describe('backend', () => {
 				});
 			});
 
-			console.log(result);
 			expect(result.after).toEqual({
 				id: result.id,
 				slug,

--- a/test/integration/backend/index.spec.ts
+++ b/test/integration/backend/index.spec.ts
@@ -4708,345 +4708,334 @@ describe('backend', () => {
 	});
 
 	describe('.stream()', () => {
-		it('should report back new elements that match a certain type', (done) => {
+		it('should report back new elements that match a certain type', async () => {
 			const randString = ctx.generateRandomSlug();
-			ctx.backend
-				.stream(
-					{
-						type: {},
-						data: {},
-					},
-					{
-						type: 'object',
-						additionalProperties: false,
-						properties: {
-							type: {
-								type: 'string',
-								const: 'foo@1.0.0',
-							},
-							data: {
-								type: 'object',
-								required: ['test'],
-								properties: {
-									test: {
-										type: 'string',
-										const: randString,
-									},
+			const emitter = await ctx.backend.stream(
+				{
+					type: {},
+					data: {},
+				},
+				{
+					type: 'object',
+					additionalProperties: false,
+					properties: {
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+						data: {
+							type: 'object',
+							required: ['test'],
+							properties: {
+								test: {
+									type: 'string',
+									const: randString,
 								},
 							},
 						},
-						required: ['type'],
 					},
-				)
-				.then(async (emitter: Stream) => {
-					emitter.on('data', (change) => {
-						expect(change.type).toBe('insert');
-						expect(change.after).toEqual({
-							type: 'foo@1.0.0',
-							data: {
-								test: randString,
-							},
-						});
+					required: ['type'],
+				},
+			);
 
-						emitter.close();
-					});
-
-					emitter.on('error', done);
-					emitter.on('closed', done);
-
-					Bluebird.all([
-						ctx.backend.insertElement(ctx.context, {
-							type: 'foo@1.0.0',
-							version: '1.0.0',
-							tags: [],
-							loop: null,
-							links: {},
-							markers: [],
-							requires: [],
-							capabilities: [],
-							linked_at: {},
-							created_at: new Date().toISOString(),
-							updated_at: null,
-							active: true,
-							slug: ctx.generateRandomSlug(),
-							data: {
-								test: randString,
-							},
-						}),
-						ctx.backend.insertElement(ctx.context, {
-							type: 'bar@1.0.0',
-							version: '1.0.0',
-							tags: [],
-							loop: null,
-							links: {},
-							markers: [],
-							requires: [],
-							capabilities: [],
-							created_at: new Date().toISOString(),
-							updated_at: null,
-							linked_at: {},
-							active: true,
-							slug: ctx.generateRandomSlug(),
-							data: {
-								test: randString,
-							},
-						}),
-					]);
+			const result = await new Promise<any>(async (resolve, reject) => {
+				emitter.on('data', (change) => {
+					resolve(change);
 				});
+
+				emitter.on('error', reject);
+
+				Bluebird.all([
+					ctx.backend.insertElement(ctx.context, {
+						type: 'foo@1.0.0',
+						version: '1.0.0',
+						tags: [],
+						loop: null,
+						links: {},
+						markers: [],
+						requires: [],
+						capabilities: [],
+						linked_at: {},
+						created_at: new Date().toISOString(),
+						updated_at: null,
+						active: true,
+						slug: ctx.generateRandomSlug(),
+						data: {
+							test: randString,
+						},
+					}),
+					ctx.backend.insertElement(ctx.context, {
+						type: 'bar@1.0.0',
+						version: '1.0.0',
+						tags: [],
+						loop: null,
+						links: {},
+						markers: [],
+						requires: [],
+						capabilities: [],
+						created_at: new Date().toISOString(),
+						updated_at: null,
+						linked_at: {},
+						active: true,
+						slug: ctx.generateRandomSlug(),
+						data: {
+							test: randString,
+						},
+					}),
+				]);
+			});
+
+			console.log(result);
+			expect(result.type).toBe('insert');
+			expect(result.after).toEqual({
+				id: result.id,
+				type: 'foo@1.0.0',
+				data: {
+					test: randString,
+				},
+			});
+
+			emitter.close();
 		});
 
-		it('should report back changes to certain elements', (done) => {
+		it('should report back changes to certain elements', async () => {
 			const slug1 = ctx.generateRandomSlug();
 			const slug2 = ctx.generateRandomSlug();
 
-			ctx.backend
-				.stream(
-					{
-						slug: {},
-						type: {},
-						data: {},
-					},
-					{
-						type: 'object',
-						additionalProperties: false,
-						properties: {
-							slug: {
-								type: 'string',
-								enum: [slug1, slug2],
-							},
-							type: {
-								type: 'string',
-								const: 'foo@1.0.0',
-							},
-							data: {
-								type: 'object',
-								required: ['test'],
-								properties: {
-									test: {
-										type: 'number',
-									},
+			const emitter = await ctx.backend.stream(
+				{
+					slug: {},
+					type: {},
+					data: {},
+				},
+				{
+					type: 'object',
+					additionalProperties: false,
+					properties: {
+						slug: {
+							type: 'string',
+							enum: [slug1, slug2],
+						},
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+						data: {
+							type: 'object',
+							required: ['test'],
+							properties: {
+								test: {
+									type: 'number',
 								},
 							},
 						},
-						required: ['type', 'slug'],
 					},
-				)
-				.then(async (emitter: Stream) => {
-					await ctx.backend.insertElement(ctx.context, {
-						type: 'foo@1.0.0',
-						version: '1.0.0',
-						links: {},
-						tags: [],
-						loop: null,
-						markers: [],
-						requires: [],
-						capabilities: [],
-						created_at: new Date().toISOString(),
-						updated_at: null,
-						linked_at: {},
-						active: true,
-						slug: slug1,
-						data: {
-							test: 1,
-						},
-					});
+					required: ['type', 'slug'],
+				},
+			);
 
-					await ctx.backend.insertElement(ctx.context, {
-						type: 'bar@1.0.0',
-						version: '1.0.0',
-						tags: [],
-						loop: null,
-						links: {},
-						markers: [],
-						requires: [],
-						capabilities: [],
-						created_at: new Date().toISOString(),
-						updated_at: null,
-						linked_at: {},
-						active: true,
-						slug: slug2,
-						data: {
-							test: 1,
-						},
-					});
+			const contract1 = await ctx.backend.insertElement(ctx.context, {
+				type: 'foo@1.0.0',
+				version: '1.0.0',
+				links: {},
+				tags: [],
+				loop: null,
+				markers: [],
+				requires: [],
+				capabilities: [],
+				created_at: new Date().toISOString(),
+				updated_at: null,
+				linked_at: {},
+				active: true,
+				slug: slug1,
+				data: {
+					test: 1,
+				},
+			});
 
-					emitter.on('data', (change) => {
-						if (change.type === 'insert') {
-							return;
-						}
+			await ctx.backend.insertElement(ctx.context, {
+				type: 'bar@1.0.0',
+				version: '1.0.0',
+				tags: [],
+				loop: null,
+				links: {},
+				markers: [],
+				requires: [],
+				capabilities: [],
+				created_at: new Date().toISOString(),
+				updated_at: null,
+				linked_at: {},
+				active: true,
+				slug: slug2,
+				data: {
+					test: 1,
+				},
+			});
 
-						expect(change.type).toBe('update');
-						expect(change.after).toEqual({
-							slug: slug1,
-							type: 'foo@1.0.0',
-							data: {
-								test: 2,
-							},
-						});
+			const result = await new Promise<any>(async (resolve, reject) => {
+				emitter.on('data', (change) => {
+					if (change.type === 'insert') {
+						return;
+					}
 
-						emitter.close();
-					});
-
-					emitter.on('error', (error) => {
-						done(error);
-					});
-
-					emitter.on('closed', () => {
-						done();
-					});
-
-					await ctx.backend.upsertElement(ctx.context, {
-						slug: slug1,
-						version: '1.0.0',
-						tags: [],
-						loop: null,
-						links: {},
-						markers: [],
-						requires: [],
-						capabilities: [],
-						created_at: new Date().toISOString(),
-						updated_at: null,
-						linked_at: {},
-						active: true,
-						type: 'foo@1.0.0',
-						data: {
-							test: 2,
-						},
-					});
-					await ctx.backend.upsertElement(ctx.context, {
-						slug: slug2,
-						active: true,
-						version: '1.0.0',
-						links: {},
-						tags: [],
-						loop: null,
-						markers: [],
-						requires: [],
-						capabilities: [],
-						created_at: new Date().toISOString(),
-						updated_at: null,
-						linked_at: {},
-						type: 'bar@1.0.0',
-						data: {
-							test: 2,
-						},
-					});
+					resolve(change);
 				});
+
+				emitter.on('error', reject);
+
+				await ctx.backend.upsertElement(ctx.context, {
+					slug: slug1,
+					version: '1.0.0',
+					tags: [],
+					loop: null,
+					links: {},
+					markers: [],
+					requires: [],
+					capabilities: [],
+					created_at: new Date().toISOString(),
+					updated_at: null,
+					linked_at: {},
+					active: true,
+					type: 'foo@1.0.0',
+					data: {
+						test: 2,
+					},
+				});
+				await ctx.backend.upsertElement(ctx.context, {
+					slug: slug2,
+					active: true,
+					version: '1.0.0',
+					links: {},
+					tags: [],
+					loop: null,
+					markers: [],
+					requires: [],
+					capabilities: [],
+					created_at: new Date().toISOString(),
+					updated_at: null,
+					linked_at: {},
+					type: 'bar@1.0.0',
+					data: {
+						test: 2,
+					},
+				});
+			});
+
+			console.log(result);
+
+			expect(result.type).toBe('update');
+			expect(result.after).toEqual({
+				id: contract1.id,
+				slug: slug1,
+				type: 'foo@1.0.0',
+				data: {
+					test: 2,
+				},
+			});
+
+			emitter.close();
 		});
 
-		it('should report back changes to large elements', (done) => {
+		it('should report back changes to large elements', async () => {
 			const slug = ctx.generateRandomSlug();
 
-			ctx.backend
-				.stream(
-					{
-						slug: {},
-						type: {},
-						data: {},
-					},
-					{
-						type: 'object',
-						additionalProperties: false,
-						properties: {
-							slug: {
-								type: 'string',
-								const: slug,
-							},
-							type: {
-								type: 'string',
-								const: 'foo@1.0.0',
-							},
-							data: {
-								type: 'object',
-								required: ['test'],
-								properties: {
-									test: {
-										type: 'string',
-									},
+			const emitter = await ctx.backend.stream(
+				{
+					slug: {},
+					type: {},
+					data: {},
+				},
+				{
+					type: 'object',
+					additionalProperties: false,
+					properties: {
+						slug: {
+							type: 'string',
+							const: slug,
+						},
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+						data: {
+							type: 'object',
+							required: ['test'],
+							properties: {
+								test: {
+									type: 'string',
 								},
 							},
 						},
-						required: ['type', 'slug'],
 					},
-				)
-				.then(async (emitter: Stream) => {
-					await ctx.backend.insertElement(ctx.context, {
-						type: 'foo@1.0.0',
-						active: true,
-						links: {},
-						version: '1.0.0',
-						tags: [],
-						loop: null,
-						markers: [],
-						requires: [],
-						capabilities: [],
-						created_at: new Date().toISOString(),
-						updated_at: null,
-						linked_at: {},
-						slug,
-						data: {
-							test: new Array(5000).join('foobar'),
-						},
-					});
+					required: ['type', 'slug'],
+				},
+			);
 
-					emitter.on('data', (change) => {
-						// Livefeeds are asynchronous and can pick up a change a
-						// moment after the insertion, so there exist the
-						// possibility that we get the initial insert event here,
-						// and if so its fine to ignore, as it doesn't affect
-						// the semantics of the tests.
-						if (
-							change.type === 'insert' &&
-							_.isEqual(change.after, {
-								slug,
-								type: 'foo@1.0.0',
-								data: {
-									test: new Array(5000).join('foobar'),
-								},
-							})
-						) {
-							return;
-						}
+			await ctx.backend.insertElement(ctx.context, {
+				type: 'foo@1.0.0',
+				active: true,
+				links: {},
+				version: '1.0.0',
+				tags: [],
+				loop: null,
+				markers: [],
+				requires: [],
+				capabilities: [],
+				created_at: new Date().toISOString(),
+				updated_at: null,
+				linked_at: {},
+				slug,
+				data: {
+					test: new Array(5000).join('foobar'),
+				},
+			});
 
-						expect(change.type).toBe('update');
-						expect(change.after).toEqual({
-							slug,
-							type: 'foo@1.0.0',
-							data: {
-								test: new Array(5000).join('bazbuzz'),
-							},
-						});
+			const result = await new Promise<any>(async (resolve, reject) => {
+				emitter.on('data', (change) => {
+					// Livefeeds are asynchronous and can pick up a change a
+					// moment after the insertion, so there exist the
+					// possibility that we get the initial insert event here,
+					// and if so its fine to ignore, as it doesn't affect
+					// the semantics of the tests.
+					if (change.type === 'insert') {
+						return;
+					}
 
-						emitter.close();
-					});
-
-					emitter.on('error', (error) => {
-						done(error);
-					});
-
-					emitter.on('closed', () => {
-						done();
-					});
-
-					ctx.backend.upsertElement(ctx.context, {
-						slug,
-						active: true,
-						version: '1.0.0',
-						links: {},
-						tags: [],
-						loop: null,
-						markers: [],
-						requires: [],
-						capabilities: [],
-						linked_at: {},
-						created_at: new Date().toISOString(),
-						updated_at: null,
-						type: 'foo@1.0.0',
-						data: {
-							test: new Array(5000).join('bazbuzz'),
-						},
-					});
+					emitter.close();
+					resolve(change);
 				});
+
+				emitter.on('error', reject);
+
+				await ctx.backend.upsertElement(ctx.context, {
+					slug,
+					active: true,
+					version: '1.0.0',
+					links: {},
+					tags: [],
+					loop: null,
+					markers: [],
+					requires: [],
+					capabilities: [],
+					linked_at: {},
+					created_at: new Date().toISOString(),
+					updated_at: null,
+					type: 'foo@1.0.0',
+					data: {
+						test: new Array(5000).join('bazbuzz'),
+					},
+				});
+			});
+
+			expect(result.type).toBe('update');
+			expect(result.after).toEqual({
+				id: result.id,
+				slug,
+				type: 'foo@1.0.0',
+				data: {
+					test: new Array(5000).join('bazbuzz'),
+				},
+			});
 		});
 
 		it('should close without finding anything', (done) => {
@@ -5073,211 +5062,206 @@ describe('backend', () => {
 				});
 		});
 
-		it('should set "before" to null if it previously did not match the schema', (done) => {
+		it('should set "before" to null if it previously did not match the schema', async () => {
 			const slug = ctx.generateRandomSlug();
-			ctx.backend
-				.stream(
-					{
-						slug: {},
-						type: {},
-						data: {},
-					},
-					{
-						type: 'object',
-						additionalProperties: false,
-						properties: {
-							slug: {
-								type: 'string',
-								const: slug,
-							},
-							type: {
-								type: 'string',
-								const: 'foo@1.0.0',
-							},
-							data: {
-								type: 'object',
-								required: ['test'],
-								properties: {
-									test: {
-										type: 'number',
-									},
+			const emitter = await ctx.backend.stream(
+				{
+					slug: {},
+					type: {},
+					data: {},
+				},
+				{
+					type: 'object',
+					additionalProperties: false,
+					properties: {
+						slug: {
+							type: 'string',
+							const: slug,
+						},
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+						data: {
+							type: 'object',
+							required: ['test'],
+							properties: {
+								test: {
+									type: 'number',
 								},
 							},
 						},
-						required: ['slug', 'type', 'data'],
 					},
-				)
-				.then(async (emitter: Stream) => {
-					await ctx.backend.insertElement(ctx.context, {
-						slug,
-						active: true,
-						links: {},
-						version: '1.0.0',
-						tags: [],
-						loop: null,
-						markers: [],
-						requires: [],
-						capabilities: [],
-						created_at: new Date().toISOString(),
-						updated_at: null,
-						linked_at: {},
-						type: 'foo@1.0.0',
-						data: {
-							test: '1',
-						},
-					});
+					required: ['slug', 'type', 'data'],
+				},
+			);
 
-					emitter.on('data', (change) => {
-						expect(change.after).toEqual({
-							slug,
-							type: 'foo@1.0.0',
-							data: {
-								test: 1,
-							},
-						});
+			await ctx.backend.insertElement(ctx.context, {
+				slug,
+				active: true,
+				links: {},
+				version: '1.0.0',
+				tags: [],
+				loop: null,
+				markers: [],
+				requires: [],
+				capabilities: [],
+				created_at: new Date().toISOString(),
+				updated_at: null,
+				linked_at: {},
+				type: 'foo@1.0.0',
+				data: {
+					test: '1',
+				},
+			});
 
-						emitter.close();
-					});
-
-					emitter.on('error', done);
-					emitter.on('closed', done);
-
-					ctx.backend.upsertElement(ctx.context, {
-						slug,
-						active: true,
-						links: {},
-						version: '1.0.0',
-						tags: [],
-						loop: null,
-						markers: [],
-						requires: [],
-						capabilities: [],
-						linked_at: {},
-						created_at: new Date().toISOString(),
-						updated_at: null,
-						type: 'foo@1.0.0',
-						data: {
-							test: 1,
-						},
-					});
+			const result = await new Promise<any>(async (resolve, reject) => {
+				emitter.on('data', (change) => {
+					resolve(change);
+					emitter.close();
 				});
+
+				emitter.on('error', reject);
+
+				await ctx.backend.upsertElement(ctx.context, {
+					slug,
+					active: true,
+					links: {},
+					version: '1.0.0',
+					tags: [],
+					loop: null,
+					markers: [],
+					requires: [],
+					capabilities: [],
+					linked_at: {},
+					created_at: new Date().toISOString(),
+					updated_at: null,
+					type: 'foo@1.0.0',
+					data: {
+						test: 1,
+					},
+				});
+			});
+
+			console.log(result);
+			expect(result.after).toEqual({
+				id: result.id,
+				slug,
+				type: 'foo@1.0.0',
+				data: {
+					test: 1,
+				},
+			});
 		});
 
-		it(
-			'should filter the "before" section of a change',
-			(done) => {
-				const slug = ctx.generateRandomSlug();
+		it('should filter the "before" section of a change', async () => {
+			const slug = ctx.generateRandomSlug();
 
-				ctx.backend
-					.stream(
-						{
-							slug: {},
-							type: {},
-							data: {},
+			const emitter = await ctx.backend.stream(
+				{
+					slug: {},
+					type: {},
+					data: {},
+				},
+				{
+					type: 'object',
+					additionalProperties: false,
+					properties: {
+						slug: {
+							type: 'string',
+							const: slug,
 						},
-						{
+						type: {
+							type: 'string',
+							const: 'foo@1.0.0',
+						},
+						data: {
 							type: 'object',
+							required: ['test'],
 							additionalProperties: false,
 							properties: {
-								slug: {
-									type: 'string',
-									const: slug,
-								},
-								type: {
-									type: 'string',
-									const: 'foo@1.0.0',
-								},
-								data: {
-									type: 'object',
-									required: ['test'],
-									additionalProperties: false,
-									properties: {
-										test: {
-											type: 'number',
-										},
-									},
+								test: {
+									type: 'number',
 								},
 							},
-							required: ['type', 'slug'],
 						},
-					)
-					.then(async (emitter: Stream) => {
-						await ctx.backend.insertElement(ctx.context, {
-							type: 'foo@1.0.0',
-							active: true,
-							links: {},
-							version: '1.0.0',
-							tags: [],
-							loop: null,
-							markers: [],
-							requires: [],
-							capabilities: [],
-							linked_at: {},
-							created_at: new Date().toISOString(),
-							updated_at: null,
-							slug,
-							data: {
-								test: 1,
-								extra: true,
-							},
-						});
+					},
+					required: ['type', 'slug'],
+				},
+			);
 
-						emitter.on('data', (change) => {
-							// Livefeeds are asynchronous and can pick up a change a
-							// moment after the insertion, so there exist the
-							// possibility that we get the initial insert event here,
-							// and if so its fine to ignore, as it doesn't affect
-							// the semantics of the tests.
-							if (
-								change.type === 'insert' &&
-								_.isEqual(change.after, {
-									type: 'foo@1.0.0',
-									slug,
-									data: {
-										test: 1,
-									},
-								})
-							) {
-								return;
-							}
+			const contract = await ctx.backend.insertElement(ctx.context, {
+				type: 'foo@1.0.0',
+				active: true,
+				links: {},
+				version: '1.0.0',
+				tags: [],
+				loop: null,
+				markers: [],
+				requires: [],
+				capabilities: [],
+				linked_at: {},
+				created_at: new Date().toISOString(),
+				updated_at: null,
+				slug,
+				data: {
+					test: 1,
+					extra: true,
+				},
+			});
 
-							expect(change.after).toEqual({
-								slug,
-								type: 'foo@1.0.0',
-								data: {
-									test: 2,
-								},
-							});
+			const result = await new Promise(async (resolve, reject) => {
+				emitter.on('data', (change) => {
+					// Livefeeds are asynchronous and can pick up a change a
+					// moment after the insertion, so there exist the
+					// possibility that we get the initial insert event here,
+					// and if so its fine to ignore, as it doesn't affect
+					// the semantics of the tests.
+					if (change.type === 'insert') {
+						return;
+					}
 
-							emitter.close();
-						});
+					emitter.close();
+					resolve(change);
+				});
 
-						emitter.on('error', done);
-						emitter.on('closed', done);
+				emitter.on('error', reject);
 
-						await ctx.backend.upsertElement(ctx.context, {
-							slug,
-							version: '1.0.0',
-							tags: [],
-							loop: null,
-							links: {},
-							markers: [],
-							requires: [],
-							capabilities: [],
-							created_at: new Date().toISOString(),
-							linked_at: {},
-							updated_at: null,
-							active: true,
-							type: 'foo@1.0.0',
-							data: {
-								test: 2,
-								extra: true,
-							},
-						});
-					});
-			},
-			10 * 1000,
-		);
+				await ctx.backend.upsertElement(ctx.context, {
+					slug,
+					version: '1.0.0',
+					tags: [],
+					loop: null,
+					links: {},
+					markers: [],
+					requires: [],
+					capabilities: [],
+					created_at: new Date().toISOString(),
+					linked_at: {},
+					updated_at: null,
+					active: true,
+					type: 'foo@1.0.0',
+					data: {
+						test: 2,
+						extra: true,
+					},
+				});
+			});
+
+			expect(result).toEqual({
+				id: contract.id,
+				contractType: contract.type,
+				type: 'update',
+				after: {
+					id: contract.id,
+					slug: contract.slug,
+					type: contract.type,
+					data: {
+						test: 2,
+					},
+				},
+			});
+		});
 
 		it('should throw if the schema is invalid', async () => {
 			await expect(

--- a/test/integration/create-relationships.ts
+++ b/test/integration/create-relationships.ts
@@ -34,7 +34,7 @@ export async function createRelationships(ctx: TestContext) {
 			fromVersionedType: 'card',
 			toVersionedType: 'card',
 			name: 'is linked to',
-			inverseName: 'has link',
+			inverseName: 'is linked to',
 			title: 'Link',
 			inverseTitle: 'Link',
 		},
@@ -86,11 +86,55 @@ export async function createRelationships(ctx: TestContext) {
 			title: 'Reporter',
 			inverseTitle: 'Manager',
 		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: '*',
+			name: 'is xxx-card-to-wildcard-xxx to',
+			inverseName: 'has xxx-card-to-wildcard-xxx element',
+			title: 'Left',
+			inverseTitle: 'Right',
+		},
+		{
+			fromVersionedType: '*',
+			toVersionedType: 'card',
+			name: 'is xxx-wildcard-to-card-xxx to',
+			inverseName: 'has xxx-wildcard-to-card-xxx element',
+			title: 'Left',
+			inverseTitle: 'Right',
+		},
+		{
+			fromVersionedType: 'card@1.0.0',
+			toVersionedType: 'card',
+			name: 'is xxx-versioned-to-card-xxx to',
+			inverseName: 'has xxx-versioned-to-card-xxx element',
+			title: 'Left',
+			inverseTitle: 'Right',
+		},
+		{
+			fromVersionedType: 'card',
+			toVersionedType: 'card',
+			name: 'is xxx-forward-xxx to',
+			inverseName: 'is xxx-reverse-xxx to',
+			title: 'Left',
+			inverseTitle: 'Right',
+		},
+		{
+			fromVersionedType: 'card@1.0.0',
+			toVersionedType: '*',
+			name: 'forwards to',
+			inverseName: 'is forwarded by',
+			title: 'Card',
+			inverseTitle: 'Destination',
+		},
 	];
 
 	const relContracts = relSpecs.map((spec) => {
-		const fromType = spec.fromVersionedType.split('@')[0];
-		const toType = spec.toVersionedType.split('@')[0];
+		const fromType =
+			spec.fromVersionedType === '*'
+				? 'any'
+				: spec.fromVersionedType.split('@')[0];
+		const toType =
+			spec.toVersionedType === '*' ? 'any' : spec.toVersionedType.split('@')[0];
 		const dashedName = _.kebabCase(spec.name);
 		return {
 			slug: `relationship-${fromType}-${dashedName}-${toType}`,

--- a/test/integration/kernel.link.spec.ts
+++ b/test/integration/kernel.link.spec.ts
@@ -2,11 +2,13 @@ import { strict as assert } from 'assert';
 import * as _ from 'lodash';
 import { v4 as uuid } from 'uuid';
 import { errors, testUtils } from '../../lib';
+import { createRelationships } from './create-relationships';
 
 let ctx: testUtils.TestContext;
 
 beforeAll(async () => {
 	ctx = await testUtils.newContext();
+	await createRelationships(ctx);
 });
 
 afterAll(async () => {
@@ -234,27 +236,6 @@ describe('Kernel', () => {
 
 			const contract2 = await insertCardContract();
 
-			await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					slug: `relationship-card-is-xxx-card-to-wildcard-xxx-to-card`,
-					type: 'relationship@1.0.0',
-					name: 'is xxx-card-to-wildcard-xxx to',
-					data: {
-						inverseName: 'has xxx-card-to-wildcard-xxx element',
-						title: 'Left',
-						inverseTitle: 'Right',
-						from: {
-							type: 'card',
-						},
-						to: {
-							type: '*',
-						},
-					},
-				},
-			);
-
 			const linkContract = await ctx.kernel.insertContract(
 				ctx.logContext,
 				ctx.kernel.adminSession()!,
@@ -290,27 +271,6 @@ describe('Kernel', () => {
 			const contract1 = await insertCardContract();
 
 			const contract2 = await insertCardContract();
-
-			await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					slug: `relationship-card-is-xxx-wildcard-to-card-xxx-to-card`,
-					type: 'relationship@1.0.0',
-					name: 'is xxx-wildcard-to-card-xxx to',
-					data: {
-						inverseName: 'has xxx-wildcard-to-card-xxx element',
-						title: 'Left',
-						inverseTitle: 'Right',
-						from: {
-							type: '*',
-						},
-						to: {
-							type: 'card',
-						},
-					},
-				},
-			);
 
 			const linkContract = await ctx.kernel.insertContract(
 				ctx.logContext,
@@ -348,27 +308,6 @@ describe('Kernel', () => {
 
 			const contract2 = await insertCardContract();
 
-			await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					slug: `relationship-card-is-xxx-versioned-to-card-xxx-to-card`,
-					type: 'relationship@1.0.0',
-					name: 'is xxx-versioned-to-card-xxx to',
-					data: {
-						inverseName: 'has xxx-versioned-to-card-xxx element',
-						title: 'Left',
-						inverseTitle: 'Right',
-						from: {
-							type: 'card@1.0.0',
-						},
-						to: {
-							type: 'card',
-						},
-					},
-				},
-			);
-
 			const linkContract = await ctx.kernel.insertContract(
 				ctx.logContext,
 				ctx.kernel.adminSession()!,
@@ -404,27 +343,6 @@ describe('Kernel', () => {
 			const contract1 = await insertCardContract();
 
 			const contract2 = await insertCardContract();
-
-			await ctx.kernel.insertContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					slug: `relationship-card-is-xxx-forward-xxx-to-card`,
-					type: 'relationship@1.0.0',
-					name: 'is xxx-forward-xxx to',
-					data: {
-						inverseName: 'is xxx-reverse-xxx to',
-						title: 'Left',
-						inverseTitle: 'Right',
-						from: {
-							type: 'card',
-						},
-						to: {
-							type: 'card',
-						},
-					},
-				},
-			);
 
 			const linkContract = await ctx.kernel.insertContract(
 				ctx.logContext,
@@ -476,30 +394,8 @@ describe('Kernel', () => {
 				},
 			);
 
-			const relationship = await ctx.kernel.replaceContract(
-				ctx.logContext,
-				ctx.kernel.adminSession()!,
-				{
-					slug: `relationship-card-forwards-to-any`,
-					type: 'relationship@1.0.0',
-					name: 'forwards to',
-					data: {
-						inverseName: 'is forwarded by',
-						title: 'Card',
-						inverseTitle: 'Destination',
-						from: {
-							type: 'card@1.0.0',
-						},
-						to: {
-							type: '*',
-						},
-					},
-				},
-			);
-
 			assert(createContract !== null);
 			assert(supportThreadContract !== null);
-			assert(relationship !== null);
 
 			const linkContract = await ctx.kernel.insertContract(
 				ctx.logContext,

--- a/test/integration/kernel.stream.spec.ts
+++ b/test/integration/kernel.stream.spec.ts
@@ -699,7 +699,7 @@ describe('Kernel', () => {
 				});
 		});
 
-		it.skip('should be able to resolve links when subsequent links of the same verb are added', async () => {
+		it('should be able to resolve links when subsequent links of the same verb are added', async () => {
 			const slug = testUtils.generateRandomSlug();
 
 			// Create the base contract, and two additional contracts to link to
@@ -851,8 +851,7 @@ describe('Kernel', () => {
 			emitter.close();
 		});
 
-		// TODO: Get this working, but in a performant way.
-		test.skip('should be able to resolve links on an update to the linked contract', (done) => {
+		test('should be able to resolve links on an update to the linked contract', (done) => {
 			const slug = testUtils.generateRandomSlug();
 
 			ctx.kernel
@@ -862,12 +861,7 @@ describe('Kernel', () => {
 							type: 'object',
 							additionalProperties: false,
 							properties: {
-								slug: {
-									type: 'string',
-								},
-								data: {
-									type: 'object',
-								},
+								slug: true,
 							},
 						},
 					},
@@ -875,15 +869,13 @@ describe('Kernel', () => {
 					additionalProperties: false,
 					properties: {
 						slug: {
-							type: 'string',
 							const: slug,
 						},
 						type: {
-							type: 'string',
 							const: 'card@1.0.0',
 						},
+						links: true,
 					},
-					required: ['type'],
 				})
 				.then(async (emitter: Stream) => {
 					const contract1 = await ctx.kernel.insertContract(
@@ -934,8 +926,8 @@ describe('Kernel', () => {
 
 					emitter.on('data', (change) => {
 						expect(change.after).toEqual({
-							type: 'card@1.0.0',
 							slug,
+							type: 'card@1.0.0',
 							links: {
 								'is attached to': [
 									{
@@ -1174,7 +1166,7 @@ describe('Kernel', () => {
 			expect(results).toEqual([contract]);
 		});
 
-		it.skip('should respond to an unmatch update to the linked contract', async () => {
+		it('should respond to an unmatch update to the linked contract', async () => {
 			const slug = testUtils.generateRandomSlug();
 
 			const contract1 = await ctx.kernel.insertContract(


### PR DESCRIPTION
Enhance streaming system to work much more effectively with queries that traverse links.
With this change, streams will now emit events for:
- Newly created links
- New links with a verb that has already been linked
- Changes to linked contracts

This currently *only works at a single level of linking*, nested links in a query will be ignored for the purposes of triggering stream events.