### PR TITLE
Avoid throwing on empty properties

### DIFF
--- a/lib/context.ts
+++ b/lib/context.ts
@@ -165,6 +165,8 @@ export class Context {
 			const result = await cbPromise;
 			return result;
 		} catch (error: unknown) {
+			// TODO convert the error into a JellyfishDatabaseError ( timeout etc)
+			// TODO log the query that failed
 			throw saneError(error);
 		} finally {
 			if (discardContext) {
@@ -324,6 +326,8 @@ export class Context {
 	/**
 	 * Run a query and return its results.
 	 */
+	// TODO either here or on withDatabaseConnection, convert the error to a JellyfishError
+	// note that await this.withDatabaseConnection doesn't have a try/catch wrapping it
 	public async query<T extends QueryResultRow = any>(
 		query: Query,
 		parameters?: any[],

--- a/lib/kernel.ts
+++ b/lib/kernel.ts
@@ -1507,7 +1507,7 @@ export class Kernel {
 								[verb]: {
 									...(schema.$$links[verb] as any),
 									properties: {
-										...((schema.$$links[verb] as any).properties || {}),
+										...((schema.$$links[verb] as any)?.properties || {}),
 										id: {
 											const: change.after.id,
 										},


### PR DESCRIPTION
this fixes:

```log
2022-09-12T23:58:05.476Z [build/index] [crit] [ERROR-SERVER-ID-[205]-PID-16478-IP-48c518345713dcf688106f49426b51b419e3212dc70776033fbd19d36854a3cb-59.9.9]: Unhandled Rejection {}
{
  context: { id: 'ERROR-SERVER-ID-[205]-PID-16478-IP-48c518345713dcf688106f49426b51b419e3212dc70776033fbd19d36854a3cb-59.9.9' },
  message: 'Unhandled Rejection',
  error: TypeError: Cannot read properties of undefined (reading 'properties')
      at Stream.<anonymous> (/usr/src/jellyfish/apps/server/node_modules/autumndb/build/kernel.js:1029:62)
}
Process exiting
```

Change-type: patch
Signed-off-by: Ramiro Gonzalez <ramiro.gonzalez@balena.io>